### PR TITLE
Add new API for Student with CRUD operations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "tasks": {
+    "build": "mvn clean install",
+    "launch": "mvn spring-boot:run"
+  }
+}

--- a/src/main/java/me/mahendra/spring_demo/controller/StudentController.java
+++ b/src/main/java/me/mahendra/spring_demo/controller/StudentController.java
@@ -1,0 +1,52 @@
+package me.mahendra.spring_demo.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import me.mahendra.spring_demo.entities.Student;
+import me.mahendra.spring_demo.service.StudentService;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/students")
+public class StudentController {
+
+    @Autowired
+    private StudentService studentService;
+
+    @GetMapping
+    public ResponseEntity<List<Student>> getAllStudents() {
+        List<Student> students = studentService.getAllStudents();
+        return new ResponseEntity<>(students, HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Student> getStudentById(@PathVariable Long id) {
+        Student student = studentService.getStudentById(id);
+        return new ResponseEntity<>(student, HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity<Student> createStudent(@Valid @RequestBody Student student) {
+        Student createdStudent = studentService.createStudent(student);
+        return new ResponseEntity<>(createdStudent, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Student> updateStudent(@PathVariable Long id, @Valid @RequestBody Student student) {
+        Student updatedStudent = studentService.updateStudent(id, student);
+        return new ResponseEntity<>(updatedStudent, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteStudent(@PathVariable Long id) {
+        studentService.deleteStudent(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/me/mahendra/spring_demo/entities/Student.java
+++ b/src/main/java/me/mahendra/spring_demo/entities/Student.java
@@ -1,0 +1,81 @@
+package me.mahendra.spring_demo.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
+
+@Entity
+public class Student {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @NotNull
+    private String name;
+
+    @Email
+    private String email;
+
+    @NotNull
+    private String standard;
+
+    @Min(5)
+    @Max(100)
+    private int age;
+
+    public Student() {
+    }
+
+    public Student(String name, String email, String standard, int age) {
+        this.name = name;
+        this.email = email;
+        this.standard = standard;
+        this.age = age;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getStandard() {
+        return standard;
+    }
+
+    public void setStandard(String standard) {
+        this.standard = standard;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+}

--- a/src/main/java/me/mahendra/spring_demo/repository/StudentRepository.java
+++ b/src/main/java/me/mahendra/spring_demo/repository/StudentRepository.java
@@ -1,0 +1,10 @@
+package me.mahendra.spring_demo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.mahendra.spring_demo.entities.Student;
+
+@Repository
+public interface StudentRepository extends JpaRepository<Student, Long> {
+}

--- a/src/main/java/me/mahendra/spring_demo/service/StudentService.java
+++ b/src/main/java/me/mahendra/spring_demo/service/StudentService.java
@@ -1,0 +1,61 @@
+package me.mahendra.spring_demo.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import me.mahendra.spring_demo.entities.Student;
+import me.mahendra.spring_demo.repository.StudentRepository;
+
+import java.util.List;
+
+@Service
+public class StudentService {
+
+    @Autowired
+    private StudentRepository studentRepository;
+
+    public List<Student> getAllStudents() {
+        return studentRepository.findAll();
+    }
+
+    public Student getStudentById(Long id) {
+        return studentRepository.findById(id).orElse(null);
+    }
+
+    public Student createStudent(Student student) {
+        validateStudentData(student);
+        return studentRepository.save(student);
+    }
+
+    public Student updateStudent(Long id, Student student) {
+        validateStudentData(student);
+        return studentRepository.findById(id)
+                   .map(existingStudent -> {
+                       existingStudent.setName(student.getName());
+                       existingStudent.setEmail(student.getEmail());
+                       existingStudent.setStandard(student.getStandard());
+                       existingStudent.setAge(student.getAge());
+                       return studentRepository.save(existingStudent);
+                   })
+                   .orElse(null); // Or throw an exception here.
+    }
+
+    public void deleteStudent(Long id) {
+        studentRepository.deleteById(id);
+    }
+
+    private void validateStudentData(Student student) {
+        if (student.getName() == null || student.getName().isEmpty()) {
+            throw new IllegalArgumentException("Student name cannot be null or empty");
+        }
+        if (student.getEmail() == null || !student.getEmail().matches("^[A-Za-z0-9+_.-]+@(.+)$")) {
+            throw new IllegalArgumentException("Invalid email address");
+        }
+        if (student.getStandard() == null || student.getStandard().isEmpty()) {
+            throw new IllegalArgumentException("Standard cannot be null or empty");
+        }
+        if (student.getAge() < 5 || student.getAge() > 100) {
+            throw new IllegalArgumentException("Age must be between 5 and 100");
+        }
+    }
+}


### PR DESCRIPTION
Add a new API for Student with CRUD operations.

* **Student Entity**
  - Add `Student` entity class with fields: id, name, email, standard, and age.
  - Annotate fields with validation constraints.
* **Student Repository**
  - Add `StudentRepository` interface extending `JpaRepository<Student, Long>`.
* **Student Service**
  - Add `StudentService` class with CRUD methods for `Student`.
  - Autowire `StudentRepository` in `StudentService`.
  - Add validation logic in `StudentService`.
* **Student Controller**
  - Add `StudentController` class with CRUD endpoints for `Student`.
  - Autowire `StudentService` in `StudentController`.
  - Use `@Valid` annotation to enforce validation constraints in `StudentController`.
* **Devcontainer Configuration**
  - Add `.devcontainer/devcontainer.json` with build and launch tasks.

